### PR TITLE
Add storybook-docs addon

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,3 +1,4 @@
 import "@storybook/addon-actions/register";
 import "@storybook/addon-links/register";
 import "@storybook/addon-storysource/register";
+import "@storybook/addon-a11y/register";

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -2,3 +2,4 @@ import "@storybook/addon-actions/register";
 import "@storybook/addon-links/register";
 import "@storybook/addon-storysource/register";
 import "@storybook/addon-a11y/register";
+import "@storybook/addon-viewport/register";

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -4,10 +4,18 @@ import { action } from "@storybook/addon-actions";
 import GlobalStyle from "../src/styled/GlobalStyles";
 import { ThemeProvider } from "styled-components";
 import theme from "../src/styled/theme";
-
+import { withA11Y } from "@storybook/addon-a11y";
 
 // Make theme available to all components
-addDecorator(story => <ThemeProvider theme={theme}> <GlobalStyle/> {story()} </ThemeProvider>)
+addDecorator(story => (
+  <ThemeProvider theme={theme}>
+    {" "}
+    <GlobalStyle /> {story()}{" "}
+  </ThemeProvider>
+));
+
+// Use withA11y to check stories for violations of accessibility guidelines
+addDecorator(withA11Y);
 
 // automatically import all files ending in *.stories.js
 configure(require.context("../src", true, /\.stories\.js$/), module);

--- a/.storybook/presets.js
+++ b/.storybook/presets.js
@@ -1,0 +1,1 @@
+module.exports = ["@storybook/addon-docs/react/preset"];

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -15,7 +15,9 @@ module.exports = ({ config }) => {
     // use @babel/plugin-proposal-class-properties for class arrow functions
     require.resolve("@babel/plugin-proposal-class-properties"),
     // use babel-plugin-remove-graphql-queries to remove static queries from components when rendering in storybook
-    require.resolve("babel-plugin-remove-graphql-queries")
+    require.resolve("babel-plugin-remove-graphql-queries"),
+    //  use babel-plugin-react-docgen to use docgen comments in your storybook-docs
+    require.resolve("babel-plugin-react-docgen")
   ];
 
   // Allows storybook/adddon-storysource to generate a decorator call in every story

--- a/package-lock.json
+++ b/package-lock.json
@@ -1703,6 +1703,180 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
+    "@storybook/addon-a11y": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-5.2.8.tgz",
+      "integrity": "sha512-rIujvSAmXhivMecdTAqIwWQ0PARLBmMBKqdLtCfkfwtRjfASJxEFGWRmRJramx37vIDYWS5r7uHfUpZbYSn6Fg==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "5.2.8",
+        "@storybook/api": "5.2.8",
+        "@storybook/client-logger": "5.2.8",
+        "@storybook/components": "5.2.8",
+        "@storybook/core-events": "5.2.8",
+        "@storybook/theming": "5.2.8",
+        "axe-core": "^3.3.2",
+        "common-tags": "^1.8.0",
+        "core-js": "^3.0.1",
+        "global": "^4.3.2",
+        "hoist-non-react-statics": "^3.3.0",
+        "memoizerific": "^1.11.3",
+        "react": "^16.8.3",
+        "react-redux": "^7.0.2",
+        "react-sizeme": "^2.5.2",
+        "redux": "^4.0.1",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.8.tgz",
+          "integrity": "sha512-yAo1N5z/45bNIQP8SD+HVTr7X898bYAtz1EZBrQ6zD8bGamzA2Br06rOLL9xXw29eQhsaVnPlqgDwCS1sTC7aQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "5.2.8",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/api": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.8.tgz",
+          "integrity": "sha512-rFrPtTFDIPQoicLwq1AVsOvZNTUKnjD1w/NX1kKcyuWLL9BcOkU3YNLBlliGBg2JX/yS+fJKMyKk4NMzNBCZCg==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "@storybook/router": "5.2.8",
+            "@storybook/theming": "5.2.8",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.3",
+            "semver": "^6.0.0",
+            "shallow-equal": "^1.1.0",
+            "store2": "^2.7.1",
+            "telejson": "^3.0.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.8.tgz",
+          "integrity": "sha512-mFwQec27QSrqcl+IH0xA+4jfoEqC4m1G99LBHt/aTDjLZXclX1A470WqeZCp7Gx4OALpaPEVTaaaKPbiKz4C6w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.8.tgz",
+          "integrity": "sha512-+oVSEJdeh7TQ1Bhanb3mCr7fc3Bug3+K79abZ28J45Ub5x4L/ZVClj1xMgUsJs30BZ5FB8vhdgH6TQb0NSxR4A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/components": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.8.tgz",
+          "integrity": "sha512-h9l/LAMaj+emUCOyY/+ETy/S3P0npwQU280J88uL4O9XJALJ72EKfyttBCvMLvpM50E+fAPeDzuYn0t5qzGGxg==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/theming": "5.2.8",
+            "@types/react-syntax-highlighter": "10.1.0",
+            "@types/react-textarea-autosize": "^4.3.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "markdown-to-jsx": "^6.9.1",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "popper.js": "^1.14.7",
+            "prop-types": "^15.7.2",
+            "react": "^16.8.3",
+            "react-dom": "^16.8.3",
+            "react-focus-lock": "^1.18.3",
+            "react-helmet-async": "^1.0.2",
+            "react-popper-tooltip": "^2.8.3",
+            "react-syntax-highlighter": "^8.0.1",
+            "react-textarea-autosize": "^7.1.0",
+            "simplebar-react": "^1.0.0-alpha.6"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.8.tgz",
+          "integrity": "sha512-NkQKC5doO/YL9gsO61bqaxgveKktkiJWZ3XyyhL1ZebgnO9wTlrU+i9b5aX73Myk1oxbicQw9KcwDGYk0qFuNQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/router": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.8.tgz",
+          "integrity": "sha512-wnbyKESUMyv9fwo9W+n4Fev/jXylB8whpjtHrOttjguUOYX1zGSHdwNI66voPetbtVLxUeHyJteJwdyRDSirJg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.8.tgz",
+          "integrity": "sha512-rGb66GkXb0jNJMH8UQ3Ru4FL+m1x0+UdxM8a8HSE/qb1GMv2qOwjVETfAL6nVL9u6ZmrtbhHoero4f6xDwZdRg==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.14",
+            "@emotion/styled": "^10.0.14",
+            "@storybook/client-logger": "5.2.8",
+            "common-tags": "^1.8.0",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.14",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "core-js": {
+          "version": "3.4.8",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.8.tgz",
+          "integrity": "sha512-b+BBmCZmVgho8KnBUOXpvlqEMguko+0P+kXCwD4vIprsXC6ht1qgPxtb1OK6XgSlrySF71wkwBQ0Hv695bk9gQ==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@storybook/addon-actions": {
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-5.2.6.tgz",
@@ -4878,6 +5052,12 @@
           }
         }
       }
+    },
+    "axe-core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.4.0.tgz",
+      "integrity": "sha512-5C0OdgxPv/DrQguO6Taj5F1dY5OlkWg4SVmZIVABFYKWlnAc5WTLPzG+xJSgIwf2fmY+NiNGiZXhXx2qT0u/9Q==",
+      "dev": true
     },
     "axios": {
       "version": "0.19.0",
@@ -16950,6 +17130,20 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.15.0"
+      }
+    },
+    "react-redux": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.3.tgz",
+      "integrity": "sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
       }
     },
     "react-side-effect": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2395,6 +2395,174 @@
         }
       }
     },
+    "@storybook/addon-viewport": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-5.2.8.tgz",
+      "integrity": "sha512-IDZWFzQ4tOJFqytyIf3v8reQagM8FB0ZVRT9r2f9JAEJizwq+kA9ulV/keVSKS0CUU/Ie4WjXypUzhGNA2UtiA==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "5.2.8",
+        "@storybook/api": "5.2.8",
+        "@storybook/client-logger": "5.2.8",
+        "@storybook/components": "5.2.8",
+        "@storybook/core-events": "5.2.8",
+        "@storybook/theming": "5.2.8",
+        "core-js": "^3.0.1",
+        "global": "^4.3.2",
+        "memoizerific": "^1.11.3",
+        "prop-types": "^15.7.2",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.8.tgz",
+          "integrity": "sha512-yAo1N5z/45bNIQP8SD+HVTr7X898bYAtz1EZBrQ6zD8bGamzA2Br06rOLL9xXw29eQhsaVnPlqgDwCS1sTC7aQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "5.2.8",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/api": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.8.tgz",
+          "integrity": "sha512-rFrPtTFDIPQoicLwq1AVsOvZNTUKnjD1w/NX1kKcyuWLL9BcOkU3YNLBlliGBg2JX/yS+fJKMyKk4NMzNBCZCg==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "@storybook/router": "5.2.8",
+            "@storybook/theming": "5.2.8",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.3",
+            "semver": "^6.0.0",
+            "shallow-equal": "^1.1.0",
+            "store2": "^2.7.1",
+            "telejson": "^3.0.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.8.tgz",
+          "integrity": "sha512-mFwQec27QSrqcl+IH0xA+4jfoEqC4m1G99LBHt/aTDjLZXclX1A470WqeZCp7Gx4OALpaPEVTaaaKPbiKz4C6w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.8.tgz",
+          "integrity": "sha512-+oVSEJdeh7TQ1Bhanb3mCr7fc3Bug3+K79abZ28J45Ub5x4L/ZVClj1xMgUsJs30BZ5FB8vhdgH6TQb0NSxR4A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/components": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.8.tgz",
+          "integrity": "sha512-h9l/LAMaj+emUCOyY/+ETy/S3P0npwQU280J88uL4O9XJALJ72EKfyttBCvMLvpM50E+fAPeDzuYn0t5qzGGxg==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/theming": "5.2.8",
+            "@types/react-syntax-highlighter": "10.1.0",
+            "@types/react-textarea-autosize": "^4.3.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "markdown-to-jsx": "^6.9.1",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "popper.js": "^1.14.7",
+            "prop-types": "^15.7.2",
+            "react": "^16.8.3",
+            "react-dom": "^16.8.3",
+            "react-focus-lock": "^1.18.3",
+            "react-helmet-async": "^1.0.2",
+            "react-popper-tooltip": "^2.8.3",
+            "react-syntax-highlighter": "^8.0.1",
+            "react-textarea-autosize": "^7.1.0",
+            "simplebar-react": "^1.0.0-alpha.6"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.8.tgz",
+          "integrity": "sha512-NkQKC5doO/YL9gsO61bqaxgveKktkiJWZ3XyyhL1ZebgnO9wTlrU+i9b5aX73Myk1oxbicQw9KcwDGYk0qFuNQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/router": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.8.tgz",
+          "integrity": "sha512-wnbyKESUMyv9fwo9W+n4Fev/jXylB8whpjtHrOttjguUOYX1zGSHdwNI66voPetbtVLxUeHyJteJwdyRDSirJg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.8.tgz",
+          "integrity": "sha512-rGb66GkXb0jNJMH8UQ3Ru4FL+m1x0+UdxM8a8HSE/qb1GMv2qOwjVETfAL6nVL9u6ZmrtbhHoero4f6xDwZdRg==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.14",
+            "@emotion/styled": "^10.0.14",
+            "@storybook/client-logger": "5.2.8",
+            "common-tags": "^1.8.0",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.14",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "core-js": {
+          "version": "3.4.8",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.8.tgz",
+          "integrity": "sha512-b+BBmCZmVgho8KnBUOXpvlqEMguko+0P+kXCwD4vIprsXC6ht1qgPxtb1OK6XgSlrySF71wkwBQ0Hv695bk9gQ==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@storybook/addons": {
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1540,6 +1540,88 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@mdx-js/loader": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.5.1.tgz",
+      "integrity": "sha512-g7BGfMdJY5ZnDjUEdGz4cfMs9Je0hGZAItGZ1rCBHtJt6SCKMy5N8qml6FJYo3pxNxWkbOCQbX85F6qsetwlAA==",
+      "dev": true,
+      "requires": {
+        "@mdx-js/mdx": "^1.5.1",
+        "@mdx-js/react": "^1.5.1",
+        "loader-utils": "1.2.3"
+      }
+    },
+    "@mdx-js/mdx": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.5.1.tgz",
+      "integrity": "sha512-VNc2U8G6RlAYGmZfFj9dRTXcyWIo7rfxuAJtjupTqdddMx5HeLOmsWBLkZt5K76Nmn/bOg6d7zwR1+5FuvjAtg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "7.6.2",
+        "@babel/plugin-syntax-jsx": "7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+        "@mdx-js/util": "^1.5.1",
+        "babel-plugin-apply-mdx-type-prop": "^1.5.1",
+        "babel-plugin-extract-import-names": "^1.5.1",
+        "camelcase-css": "2.0.1",
+        "detab": "2.0.2",
+        "hast-util-raw": "5.0.1",
+        "lodash.uniq": "4.5.0",
+        "mdast-util-to-hast": "6.0.2",
+        "remark-mdx": "^1.5.1",
+        "remark-parse": "7.0.1",
+        "remark-squeeze-paragraphs": "3.0.4",
+        "style-to-object": "0.2.3",
+        "unified": "8.3.2",
+        "unist-builder": "1.0.4",
+        "unist-util-visit": "2.0.0"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.2.tgz",
+          "integrity": "sha512-l8zto/fuoZIbncm+01p8zPSDZu/VuuJhAfA7d/AbzM09WR7iVhavvfNDYCNpo1VvLk6E6xgAoP9P+/EMJHuRkQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.2",
+            "@babel/helpers": "^7.6.2",
+            "@babel/parser": "^7.6.2",
+            "@babel/template": "^7.6.0",
+            "@babel/traverse": "^7.6.2",
+            "@babel/types": "^7.6.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@mdx-js/react": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.5.1.tgz",
+      "integrity": "sha512-eF05YysHqtyXerLId0kPKtxmJ3PE60GJJvx1gOguEQndbs94fUeYTVSfBlnXPPAAzvOmVKrZmktIYsBQlVjpOw==",
+      "dev": true
+    },
+    "@mdx-js/util": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.5.1.tgz",
+      "integrity": "sha512-8F8E5FPWKP/cHjjI+O6Sh4KLUktk0KKS1xrxqVoBQd14/PBDH+kUgSJVE99p9jSRGh+OjCBmqx0tXN+m32w1tA==",
+      "dev": true
+    },
     "@mikaelkristiansson/domready": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@mikaelkristiansson/domready/-/domready-1.0.9.tgz",
@@ -1647,6 +1729,180 @@
           "version": "3.4.2",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.2.tgz",
           "integrity": "sha512-bUTfqFWtNKWp73oNIfRkqwYZJeNT3lstzZcAkhhiuvDraRSgOH1/+F9ZklbpR4zpdKuo4cpXN8tKP7s61yjX+g==",
+          "dev": true
+        }
+      }
+    },
+    "@storybook/addon-docs": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-5.2.8.tgz",
+      "integrity": "sha512-MOPDQ717ezD1wrDfTlaRosSnxYtTWAuFD0Eh2XGqZ5mYxt70EwUZipKEik9B7I41qqmUEUrbWlGo75wSb+aOew==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.7.2",
+        "@babel/parser": "^7.7.3",
+        "@babel/plugin-transform-react-jsx": "^7.7.0",
+        "@mdx-js/loader": "^1.1.0",
+        "@mdx-js/mdx": "^1.1.0",
+        "@mdx-js/react": "^1.0.27",
+        "@storybook/addons": "5.2.8",
+        "@storybook/api": "5.2.8",
+        "@storybook/components": "5.2.8",
+        "@storybook/router": "5.2.8",
+        "@storybook/source-loader": "5.2.8",
+        "@storybook/theming": "5.2.8",
+        "core-js": "^3.0.1",
+        "global": "^4.3.2",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.8.tgz",
+          "integrity": "sha512-yAo1N5z/45bNIQP8SD+HVTr7X898bYAtz1EZBrQ6zD8bGamzA2Br06rOLL9xXw29eQhsaVnPlqgDwCS1sTC7aQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "5.2.8",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/api": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.8.tgz",
+          "integrity": "sha512-rFrPtTFDIPQoicLwq1AVsOvZNTUKnjD1w/NX1kKcyuWLL9BcOkU3YNLBlliGBg2JX/yS+fJKMyKk4NMzNBCZCg==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "@storybook/router": "5.2.8",
+            "@storybook/theming": "5.2.8",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.3",
+            "semver": "^6.0.0",
+            "shallow-equal": "^1.1.0",
+            "store2": "^2.7.1",
+            "telejson": "^3.0.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.8.tgz",
+          "integrity": "sha512-mFwQec27QSrqcl+IH0xA+4jfoEqC4m1G99LBHt/aTDjLZXclX1A470WqeZCp7Gx4OALpaPEVTaaaKPbiKz4C6w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.8.tgz",
+          "integrity": "sha512-+oVSEJdeh7TQ1Bhanb3mCr7fc3Bug3+K79abZ28J45Ub5x4L/ZVClj1xMgUsJs30BZ5FB8vhdgH6TQb0NSxR4A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/components": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.8.tgz",
+          "integrity": "sha512-h9l/LAMaj+emUCOyY/+ETy/S3P0npwQU280J88uL4O9XJALJ72EKfyttBCvMLvpM50E+fAPeDzuYn0t5qzGGxg==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/theming": "5.2.8",
+            "@types/react-syntax-highlighter": "10.1.0",
+            "@types/react-textarea-autosize": "^4.3.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "markdown-to-jsx": "^6.9.1",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "popper.js": "^1.14.7",
+            "prop-types": "^15.7.2",
+            "react": "^16.8.3",
+            "react-dom": "^16.8.3",
+            "react-focus-lock": "^1.18.3",
+            "react-helmet-async": "^1.0.2",
+            "react-popper-tooltip": "^2.8.3",
+            "react-syntax-highlighter": "^8.0.1",
+            "react-textarea-autosize": "^7.1.0",
+            "simplebar-react": "^1.0.0-alpha.6"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.8.tgz",
+          "integrity": "sha512-NkQKC5doO/YL9gsO61bqaxgveKktkiJWZ3XyyhL1ZebgnO9wTlrU+i9b5aX73Myk1oxbicQw9KcwDGYk0qFuNQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/router": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.8.tgz",
+          "integrity": "sha512-wnbyKESUMyv9fwo9W+n4Fev/jXylB8whpjtHrOttjguUOYX1zGSHdwNI66voPetbtVLxUeHyJteJwdyRDSirJg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.8.tgz",
+          "integrity": "sha512-rGb66GkXb0jNJMH8UQ3Ru4FL+m1x0+UdxM8a8HSE/qb1GMv2qOwjVETfAL6nVL9u6ZmrtbhHoero4f6xDwZdRg==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.14",
+            "@emotion/styled": "^10.0.14",
+            "@storybook/client-logger": "5.2.8",
+            "common-tags": "^1.8.0",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.14",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "core-js": {
+          "version": "3.4.8",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.8.tgz",
+          "integrity": "sha512-b+BBmCZmVgho8KnBUOXpvlqEMguko+0P+kXCwD4vIprsXC6ht1qgPxtb1OK6XgSlrySF71wkwBQ0Hv695bk9gQ==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -3934,6 +4190,12 @@
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.32.tgz",
       "integrity": "sha1-DTyzECL4Qn6ljACK8yuA2hJspOM="
     },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
     "@types/webpack-env": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.14.1.tgz",
@@ -4808,6 +5070,16 @@
       "integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=",
       "dev": true
     },
+    "babel-plugin-apply-mdx-type-prop": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.5.1.tgz",
+      "integrity": "sha512-IFw+JDoWizgor39KsCB+Hqm/77tRSkHMRmKukDA4ul3sygZh33QtoirIpsdWWMPP9XBeOQdxuJUQdVQYrd6iOQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@mdx-js/util": "^1.5.1"
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.2.0.tgz",
@@ -4832,6 +5104,15 @@
         "escape-string-regexp": "^1.0.5",
         "find-root": "^1.1.0",
         "source-map": "^0.5.7"
+      }
+    },
+    "babel-plugin-extract-import-names": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.5.1.tgz",
+      "integrity": "sha512-08+FQtoth4uUB7jzqEgedg/ZjrFEgwFe3WVPGp7XGP5XAmmAd/SEU/z/ZhSJTeH40IVQLRfh9VJU6hGwUePINA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "babel-plugin-macros": {
@@ -5406,6 +5687,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "bail": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -6025,6 +6312,12 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
+    "camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true
+    },
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
@@ -6073,6 +6366,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz",
       "integrity": "sha512-u5ElzokS8A1pm9vM3/iDgTcI3xqHxuCao94Oz8etI3cf0Tio0p8izkDYbTIn09uP3yUUr6+veaE6IkjnTYS46g==",
+      "dev": true
+    },
+    "ccount": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+      "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
       "dev": true
     },
     "chalk": {
@@ -6499,6 +6798,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collapse-white-space": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+      "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -7480,6 +7785,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detab": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.2.tgz",
+      "integrity": "sha512-Q57yPrxScy816TTE1P/uLRXLDKjXhvYTbfxS/e6lPD+YrqghbsMlGB9nQzj/zVtSPaF0DFPSdO916EWO4sQUyQ==",
+      "dev": true,
+      "requires": {
+        "repeat-string": "^1.5.4"
+      }
     },
     "detect-indent": {
       "version": "6.0.0",
@@ -8773,6 +9087,12 @@
           }
         }
       }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -11314,11 +11634,75 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hast-to-hyperscript": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-7.0.4.tgz",
+      "integrity": "sha512-vmwriQ2H0RPS9ho4Kkbf3n3lY436QKLq6VaGA1pzBh36hBi3tm1DO9bR+kaJIbpT10UqaANDkMjxvjVfr+cnOA==",
+      "dev": true,
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "property-information": "^5.3.0",
+        "space-separated-tokens": "^1.0.0",
+        "style-to-object": "^0.2.1",
+        "unist-util-is": "^3.0.0",
+        "web-namespaces": "^1.1.2"
+      }
+    },
+    "hast-util-from-parse5": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.2.tgz",
+      "integrity": "sha512-YXFjoRS7ES7PEoLx6uihtSfKTO1s3z/tzGiV5cVpsUiihduogFXubNRCzTIW3yOOGO1nws9CxPq4MbwD39Uo+w==",
+      "dev": true,
+      "requires": {
+        "ccount": "^1.0.3",
+        "hastscript": "^5.0.0",
+        "property-information": "^5.0.0",
+        "web-namespaces": "^1.1.2",
+        "xtend": "^4.0.1"
+      }
+    },
     "hast-util-parse-selector": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.3.tgz",
       "integrity": "sha512-nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q==",
       "dev": true
+    },
+    "hast-util-raw": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-5.0.1.tgz",
+      "integrity": "sha512-iHo7G6BjRc/GU1Yun5CIEXjil0wVnIbz11C6k0JdDichSDMtYi2+NNtk6YN7EOP0JfPstX30d3pRLfaJv5CkdA==",
+      "dev": true,
+      "requires": {
+        "hast-util-from-parse5": "^5.0.0",
+        "hast-util-to-parse5": "^5.0.0",
+        "html-void-elements": "^1.0.1",
+        "parse5": "^5.0.0",
+        "unist-util-position": "^3.0.0",
+        "web-namespaces": "^1.0.0",
+        "xtend": "^4.0.1",
+        "zwitch": "^1.0.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "dev": true
+        }
+      }
+    },
+    "hast-util-to-parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-5.1.1.tgz",
+      "integrity": "sha512-ivCeAd5FCXr7bapJIVsWMnx/EmbjkkW2TU2hd1prq+jGwiaUoK+FcpjyPNwsC5ogzCwWO669tOqIovGeLc/ntg==",
+      "dev": true,
+      "requires": {
+        "hast-to-hyperscript": "^7.0.0",
+        "property-information": "^5.0.0",
+        "web-namespaces": "^1.0.0",
+        "xtend": "^4.0.1",
+        "zwitch": "^1.0.0"
+      }
     },
     "hastscript": {
       "version": "5.1.1",
@@ -11433,6 +11817,12 @@
           "dev": true
         }
       }
+    },
+    "html-void-elements": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.4.tgz",
+      "integrity": "sha512-yMk3naGPLrfvUV9TdDbuYXngh/TpHbA6TrOw3HL9kS8yhwx7i309BReNg7CbAJXGE+UMJ6je5OqJ7lC63o6YuQ==",
+      "dev": true
     },
     "html-webpack-plugin": {
       "version": "4.0.0-beta.11",
@@ -11960,6 +12350,12 @@
         "cli-spinners": "^1.0.0",
         "prop-types": "^15.5.10"
       }
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
+      "dev": true
     },
     "inquirer": {
       "version": "7.0.0",
@@ -12521,6 +12917,12 @@
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.3.1.tgz",
       "integrity": "sha512-seFn10yAXy+yJlTRO+8VfiafC+0QJanGLMPTBWLrJm/QPauuchy0UXh8B6H5o9VA8BAzk0iYievt6mNp6gfaqA=="
     },
+    "is-whitespace-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
+      "dev": true
+    },
     "is-window": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
@@ -12531,6 +12933,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "is-word-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
+      "dev": true
     },
     "is-wsl": {
       "version": "2.1.1",
@@ -12598,6 +13006,12 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
+    },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -13624,6 +14038,12 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-escapes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+      "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
+      "dev": true
+    },
     "markdown-to-jsx": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.10.3.tgz",
@@ -13662,10 +14082,75 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdast-squeeze-paragraphs": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-3.0.5.tgz",
+      "integrity": "sha512-xX6Vbe348Y/rukQlG4W3xH+7v4ZlzUbSY4HUIQCuYrF2DrkcHx584mCaFxkWoDZKNUfyLZItHC9VAqX3kIP7XA==",
+      "dev": true,
+      "requires": {
+        "unist-util-remove": "^1.0.0"
+      }
+    },
+    "mdast-util-definitions": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
+      "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "^1.0.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        }
+      }
+    },
+    "mdast-util-to-hast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-6.0.2.tgz",
+      "integrity": "sha512-GjcOimC9qHI0yNFAQdBesrZXzUkRdFleQlcoU8+TVNfDW6oLUazUx8MgUoTaUyCJzBOnE5AOgqhpURrSlf0QwQ==",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "^1.0.0",
+        "detab": "^2.0.0",
+        "mdast-util-definitions": "^1.2.0",
+        "mdurl": "^1.0.1",
+        "trim": "0.0.1",
+        "trim-lines": "^1.0.0",
+        "unist-builder": "^1.0.1",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        }
+      }
+    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "meant": {
       "version": "1.0.1",
@@ -16752,6 +17237,87 @@
         "fbjs": "^1.0.0"
       }
     },
+    "remark-mdx": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.5.1.tgz",
+      "integrity": "sha512-emKP/F1VV/k7iKGOfSChTIGocKHXbiDtdn4icefpJUedxLXlNYXe+jiSDSqlBhkv/mmN4poDTTHvFEIV6vpd4w==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "7.6.2",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.6.2",
+        "@babel/plugin-syntax-jsx": "7.2.0",
+        "@mdx-js/util": "^1.5.1",
+        "is-alphabetical": "1.0.3",
+        "remark-parse": "7.0.1",
+        "unified": "8.3.2"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.2.tgz",
+          "integrity": "sha512-l8zto/fuoZIbncm+01p8zPSDZu/VuuJhAfA7d/AbzM09WR7iVhavvfNDYCNpo1VvLk6E6xgAoP9P+/EMJHuRkQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.2",
+            "@babel/helpers": "^7.6.2",
+            "@babel/parser": "^7.6.2",
+            "@babel/template": "^7.6.0",
+            "@babel/traverse": "^7.6.2",
+            "@babel/types": "^7.6.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "remark-parse": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.1.tgz",
+      "integrity": "sha512-WOZLa545jYXtSy+txza6ACudKWByQac4S2DmGk+tAGO/3XnVTOxwyCIxB7nTcLlk8Aayhcuf3cV1WV6U6L7/DQ==",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-squeeze-paragraphs": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-3.0.4.tgz",
+      "integrity": "sha512-Wmz5Yj9q+W1oryo8BV17JrOXZgUKVcpJ2ApE2pwnoHwhFKSk4Wp2PmFNbmJMgYSqAdFwfkoe+TSYop5Fy8wMgA==",
+      "dev": true,
+      "requires": {
+        "mdast-squeeze-paragraphs": "^3.0.0"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -16778,6 +17344,12 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -17848,6 +18420,12 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.0.tgz",
       "integrity": "sha512-Vx6W1Yvy+AM1R/ckVwcHQHV147pTPBKWCRLrXMuPrFVfvBUc3os7PR1QLIWCMhPpRg5eX9ojzbQIMLGBwyLjqg=="
     },
+    "state-toggle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+      "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -18138,6 +18716,15 @@
             "ajv-keywords": "^3.1.0"
           }
         }
+      }
+    },
+    "style-to-object": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.3.tgz",
+      "integrity": "sha512-1d/k4EY2N7jVLOqf2j04dTc37TPOv/hHxZmvpg8Pdh8UYydxeu/C1W1U4vD8alzf5V2Gt7rLsmkr4dxAlDm9ng==",
+      "dev": true,
+      "requires": {
+        "inline-style-parser": "0.1.1"
       }
     },
     "styled-components": {
@@ -18558,6 +19145,30 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
+    "trim-lines": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.2.tgz",
+      "integrity": "sha512-3GOuyNeTqk3FAqc3jOJtw7FTjYl94XBR5aD9QnDbK/T4CA9sW/J0l9RoaRPE9wyPP7NF331qnHnvJFBJ+IDkmQ==",
+      "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
+      "dev": true
+    },
+    "trough": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+      "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
+      "dev": true
+    },
     "true-case-path": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
@@ -18648,6 +19259,16 @@
       "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==",
       "dev": true
     },
+    "unherit": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+      "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -18671,6 +19292,27 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
+    },
+    "unified": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.3.2.tgz",
+      "integrity": "sha512-NDtUAXcd4c+mKppCbsZHzmhkKEQuhveZNBrFYmNgMIMk2K9bc8hmG3mLEGVtRmSNodobwyMePAnvIGVWZfPdzQ==",
+      "dev": true,
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==",
+          "dev": true
+        }
+      }
     },
     "union-value": {
       "version": "1.0.1",
@@ -18715,6 +19357,109 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "unist-builder": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
+      "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.0"
+      }
+    },
+    "unist-util-generated": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.5.tgz",
+      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw==",
+      "dev": true
+    },
+    "unist-util-is": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+      "dev": true
+    },
+    "unist-util-position": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.4.tgz",
+      "integrity": "sha512-tWvIbV8goayTjobxDIr4zVTyG+Q7ragMSMeKC3xnPl9xzIc0+she8mxXLM3JVNDDsfARPbCd3XdzkyLdo7fF3g==",
+      "dev": true
+    },
+    "unist-util-remove": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-1.0.3.tgz",
+      "integrity": "sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^3.0.0"
+      }
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        }
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
+      "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
+    "unist-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.0.tgz",
+      "integrity": "sha512-kiTpWKsF54u/78L/UU/i7lxrnqGiEWBgqCpaIZBYP0gwUC+Akq0Ajm4U8JiNIoQNfAioBdsyarnOcTEAb9mLeQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.1.tgz",
+          "integrity": "sha512-7NYjErP4LJtkEptPR22wO5RsCPnHZZrop7t2SoQzjvpFedCFer4WW8ujj9GI5DkUX7yVcffXLjoURf6h2QUv6Q==",
+          "dev": true
+        },
+        "unist-util-visit-parents": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.1.tgz",
+          "integrity": "sha512-umEOTkm6/y1gIqPrqet55mYqlvGXCia/v1FSc5AveLAI7jFmOAIbqiwcHcviLcusAkEQt1bq2hixCKO9ltMb2Q==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0"
+          }
+        }
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^3.0.0"
       }
     },
     "universalify": {
@@ -18989,6 +19734,43 @@
       "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
       "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw=="
     },
+    "vfile": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
+      "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
+      "dev": true
+    },
+    "vfile-message": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
+      "integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      }
+    },
     "vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -19045,6 +19827,12 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "web-namespaces": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.3.tgz",
+      "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA==",
+      "dev": true
     },
     "webpack": {
       "version": "4.41.2",
@@ -19943,6 +20731,12 @@
           "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
         }
       }
+    },
+    "zwitch": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.4.tgz",
+      "integrity": "sha512-YO803/X+13GNaZB7fVopjvHH0uWQKgJkgKnU1YCjxShjKGVuN9PPHHW8g+uFDpkHpSTNi3rCMKMewIcbC1BAYg==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
   "devDependencies": {
     "@babel/core": "^7.7.4",
     "@storybook/addon-actions": "^5.2.6",
+    "@storybook/addon-docs": "^5.2.8",
     "@storybook/addon-links": "^5.2.8",
     "@storybook/addon-storysource": "^5.2.8",
     "@storybook/addons": "^5.2.6",
     "@storybook/react": "^5.2.6",
     "babel-loader": "^8.0.6",
+    "babel-plugin-react-docgen": "^3.2.0",
     "babel-plugin-remove-graphql-queries": "^2.7.16",
     "babel-plugin-styled-components": "^1.10.6",
     "eslint": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.4",
+    "@storybook/addon-a11y": "^5.2.8",
     "@storybook/addon-actions": "^5.2.6",
     "@storybook/addon-docs": "^5.2.8",
     "@storybook/addon-links": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@storybook/addon-docs": "^5.2.8",
     "@storybook/addon-links": "^5.2.8",
     "@storybook/addon-storysource": "^5.2.8",
+    "@storybook/addon-viewport": "^5.2.8",
     "@storybook/addons": "^5.2.6",
     "@storybook/react": "^5.2.6",
     "babel-loader": "^8.0.6",

--- a/src/NamingConvention.stories.mdx
+++ b/src/NamingConvention.stories.mdx
@@ -1,0 +1,39 @@
+# Naming conventions
+This document lays down guidelines for naming conventions to be followed across Storyblok, Storybook, and the Gatsby app.
+
+## **Storyblok** - Content types
+Content types are entries on Storyblok that usually correspond to the type of content a single page holds. Eg. publication, article
+Storyblok: stories of the type content-type
+Storybook: emplates
+Gatsby: (page-level) templates. See templates/ folder
+
+Naming: Singular, lowercase with hyphens (kebab case)
+Correct - publication, article, case-study, team-member
+Incorrect - Publication, publications, caseStudy, casestudy
+
+## **Storyblok** - Database fields
+Are fields used the define the parts of the schema in Storyblok content-types as well as components.
+Naming: All caps, underscores
+Correct - IS_HIGHLIGHTED, TEXT, FEATURED_IMAGE
+Incorrect - is_highlighted, isHighlighted
+
+
+## Components
+Are component blocks on Storyblok. Eg. CaseStudyHeader, ArticleFeaturedImage
+Storyblok: Components
+Storybook: Components
+Gatsby: Components. See components/ folder
+Naming: Singular, capitalized, camelcase
+Correct - CaseStudyHeader, ArticleFeaturedImage
+Incorrect - caseStudyHeader, case_study_header, Case_Study_Header
+
+
+## Components with state (WIP)
+Are immutable variants for a component. Defined as an independent component block on Storyblok.
+Storyblok: (TODO - need to figure how to extend components)
+Storybook: states/variants of a component
+Gatsby: variants defined by component props
+Naming: [ComponentName]_[state/variant/any modifier in camelcase]
+Correct - CaseStudyHeader_small, ArticleFeaturedImage_isHiglighted
+Incorrect - caseStudyHeader, case_study_header, Case_Study_Header
+

--- a/src/components/atoms/BodyText.js
+++ b/src/components/atoms/BodyText.js
@@ -28,6 +28,9 @@ const BodyText1Container = styled.div`
   }
 `;
 
+/**
+ * Use `BodyText1` to make a large point; for example to showcase some statistics in a graoh
+ */
 export const BodyText1 = ({ richText, ...otherProps }) => (
   <BodyText1Container
     {...otherProps}

--- a/src/components/atoms/HeaderText.js
+++ b/src/components/atoms/HeaderText.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import SbEditable from "storyblok-react";
 
@@ -8,11 +9,18 @@ const HeaderText1Container = styled.h1`
   font-weight: 700;
 `;
 
+/**
+ * Use `HeaderText[1-6]` for headers of sizes 1-6
+ */
 export const HeaderText1 = ({ children, ...otherProps }) => (
   <SbEditable content={{ children, ...otherProps }}>
     <HeaderText1Container {...otherProps}>{children}</HeaderText1Container>
   </SbEditable>
 );
+
+HeaderText1.propTypes = {
+  children: PropTypes.string.isRequired
+};
 
 const HeaderText2Container = styled.h2`
   font-size: ${props => props.theme.fontSizes[2]};

--- a/src/components/atoms/HeaderText.stories.js
+++ b/src/components/atoms/HeaderText.stories.js
@@ -12,7 +12,8 @@ export default {
   title: "Headers",
   parameters: {
     componentSubtitle: "All the titles available for use in the project"
-  }
+  },
+  component: HeaderText1
 };
 
 export const h1 = () => <HeaderText1>This is an H1</HeaderText1>;

--- a/src/components/atoms/HeaderText.stories.js
+++ b/src/components/atoms/HeaderText.stories.js
@@ -9,7 +9,10 @@ import {
 } from "./HeaderText";
 
 export default {
-  title: "Headers"
+  title: "Headers",
+  parameters: {
+    componentSubtitle: "All the titles available for use in the project"
+  }
 };
 
 export const h1 = () => <HeaderText1>This is an H1</HeaderText1>;


### PR DESCRIPTION
Things that are still broken:
- Descriptions from the component file needs to show up
- proptypes needs to show up, these are both probably a react-docgen dependency that doesn't yet work because Gatsby
- mdx files need to be displayed, probably also a webpack/gatsby issue
- the template files do not work, I'm guessing because it is unable to access the presets the storybook-docs addon needs to give to it 

Also see:
https://github.com/storybookjs/storybook/issues/8425
https://github.com/storybookjs/storybook/issues/8414